### PR TITLE
feat(OTK-30): implement coinbase notification type detection logic, grant spend permission, and sign in with hardcoded passkey

### DIFF
--- a/example/frontend/e2e/coinbaseWallet.spec.ts
+++ b/example/frontend/e2e/coinbaseWallet.spec.ts
@@ -115,6 +115,10 @@ test.describe("Coinbase Wallet Transaction Handling", () => {
       // trigger the transaction (e.g., click send, etc.)
     ])
     await notificationPopup1.waitForLoadState("domcontentloaded")
+    await notificationPopup1.waitForSelector(
+      '[data-testid="allow-authorize-button"]',
+      { timeout: 10000 },
+    )
     const notifType1 =
       await coinbase.notificationPage.identifyNotificationType(
         notificationPopup1,

--- a/src/wallets/Coinbase/pages/NotificationPage/index.ts
+++ b/src/wallets/Coinbase/pages/NotificationPage/index.ts
@@ -127,6 +127,7 @@ export class NotificationPage extends BasePage {
         return type
       }
     }
+
     throw new Error(
       `Unknown notification type: no known text found. Body text: ${pageContent.substring(
         0,


### PR DESCRIPTION
## Description
- Refactors and extends notification type detection for Coinbase Wallet extension popups in Playwright E2E tests
- Ensures reliable detection of all notification types (signature, connect, grantSpendPermission, signIn, etc.)
- Implements automation for grant spend permission and sign-in flows using a hardcoded passkey credential
- Improves error handling and debug logging in notification and passkey flows
- Updates Playwright E2E tests in example/frontend/e2e/coinbaseSmartWallet.spec.ts to cover all major notification and passkey scenarios
- Enhances code maintainability, extensibility, and alignment with OnchainTestKit architecture
<!--
A clear and concise description of:
- What the change is
- Why it's being made
- If it fixes an open issue, link to it here (e.g., "Fixes #123")
-->


## Type of Change

<!--
Please delete the options that are not relevant.
-->
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Please go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask!
-->
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [x] My code follows the style guidelines of this project (e.g., `yarn lint`, `yarn format`).
- [x] I have performed a self-review of my code.
- [ ] I have updated documentation to reflect my changes (if applicable).
- [x] I have added tests for my changes (if applicable, and new/existing tests pass).
- [ ] All commits in this PR are signed.