### PR TITLE
fix(OTK-49): update minimatch from 9.0.5 to 10.2.3 - high severity vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ws": "^8.17.1",
     "@babel/runtime": "^7.26.10",
     "brace-expansion": "^2.0.2",
-    "ajv": "^8.18.0"
+    "ajv": "^8.18.0",
+    "minimatch": "^10.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,22 +947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -5783,30 +5767,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3":
-  version: 10.0.3
-  resolution: "minimatch@npm:10.0.3"
+"minimatch@npm:^10.2.3":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.1, minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates `minimatch` from 9.0.5 to ^10.2.3 to address a HIGH severity vulnerability flagged by Coinbase's Third-Party Software Risk program.

`minimatch@9.0.5` is a transitive dependency brought in by `glob@10.x` and `@typescript-eslint/typescript-estree`. Since it is not a direct dependency, this fix adds a Yarn resolution override in the root `package.json` to force all `minimatch` instances to resolve to `^10.2.3`.

Fixes [OTK-49](https://linear.app/coinbase/issue/OTK-49/update-minimatch-from-905-to-1023-high-severity-vulnerability-fix)

**Vulnerability Details:**
- **Severity:** HIGH
- **Fix By Date:** 2026-03-20
- **Component:** `pkg:npm/minimatch@9.0.5`
- **Recommended Version:** 10.2.3

## Type of Change

- [x] Chore (e.g., refactoring, build improvements, tooling, dependency updates)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [x] My code follows the style guidelines of this project (e.g., `yarn lint`, `yarn format`).
- [x] I have performed a self-review of my code.
- [x] I have updated documentation to reflect my changes (if applicable).
- [x] I have added tests for my changes (if applicable, and new/existing tests pass).
- [x] All commits in this PR are signed.

Made with [Cursor](https://cursor.com)