### PR TITLE
modify config builder timeout

### DIFF
--- a/src/configBuilder.ts
+++ b/src/configBuilder.ts
@@ -182,6 +182,11 @@ abstract class BaseWalletBuilder<T extends WalletType> {
     return this
   }
 
+  withTimeout(ms: number) {
+    this.config.timeout = ms
+    return this
+  }
+
   setNodeConfig(config?: NodeConfig) {
     this.nodeConfig = config
   }

--- a/src/wallets/BaseWallet.ts
+++ b/src/wallets/BaseWallet.ts
@@ -39,6 +39,7 @@ export type ActionOptions = {
 export type WalletSetupContext = { localNodePort: number }
 
 export type BaseWalletConfig = {
+  timeout?: number
   type: "metamask" | "coinbase" | "phantom"
   password?: string
   walletSetup?: (

--- a/src/wallets/MetaMask/index.ts
+++ b/src/wallets/MetaMask/index.ts
@@ -61,7 +61,7 @@ export class MetaMask extends BaseWallet {
     this.config = walletConfig
     this.onboardingPage = new OnboardingPage(page)
     this.homePage = new HomePage(page)
-    this.notificationPage = new NotificationPage(page)
+    this.notificationPage = new NotificationPage(page, walletConfig.timeout)
   }
 
   static async initialize(

--- a/src/wallets/MetaMask/pages/NotificationPage/index.ts
+++ b/src/wallets/MetaMask/pages/NotificationPage/index.ts
@@ -30,13 +30,16 @@ const WAIT_FOR_PAGE_TIMEOUT_MS = 15_000
 export class NotificationPage {
   readonly page: Page
 
+  private readonly timeout: number
+
   // Cached notification page from identifyNotificationType so the
   // immediately-following action handler can reuse it instead of doing
   // a second waitForPage lookup (which risks grabbing a stale page on CI).
   private cachedNotificationPage: Page | null = null
 
-  constructor(page: Page) {
+  constructor(page: Page, timeout: number = WAIT_FOR_PAGE_TIMEOUT_MS) {
     this.page = page
+    this.timeout = timeout
   }
 
   /**
@@ -55,7 +58,10 @@ export class NotificationPage {
    * (event listener + polling), and action handlers now wait for page
    * close so stale pages are no longer in context.pages().
    */
-  private async getNotificationPage(extensionId: string): Promise<Page> {
+  private async getNotificationPage(
+    extensionId: string,
+    timeout: number = this.timeout,
+  ): Promise<Page> {
     if (
       this.cachedNotificationPage &&
       !this.cachedNotificationPage.isClosed()
@@ -84,11 +90,11 @@ export class NotificationPage {
           () =>
             reject(
               new Error(
-                `Notification page not found after ${WAIT_FOR_PAGE_TIMEOUT_MS}ms. ` +
+                `Notification page not found after ${timeout}ms. ` +
                   `The MetaMask popup may not have appeared. URL: ${targetUrl}`,
               ),
             ),
-          WAIT_FOR_PAGE_TIMEOUT_MS,
+          timeout,
         ),
       ),
     ])

--- a/src/wallets/types.ts
+++ b/src/wallets/types.ts
@@ -18,6 +18,7 @@ export type BaseWalletConfig = {
 }
 
 export type MetaMaskConfig = {
+  timeout?: number
   password: string
   walletSetup: (
     wallet: MetaMask,


### PR DESCRIPTION
## Description

This pr fixes #203 and adds a `.withTimeout(ms)` method to the config builder that lets users
configure how long the toolkit waits for MetaMask notification popups
to appear. Previously this was hardcoded to 15 seconds with no way to
change it, which caused  test to fail on slow CI machines.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [X] My code follows the style guidelines of this project (e.g., `yarn lint`, `yarn format`).
- [X] I have performed a self-review of my code.
- [X] I have updated documentation to reflect my changes (if applicable).
- [X] I have added tests for my changes (if applicable, and new/existing tests pass).
- [X] All commits in this PR are signed.